### PR TITLE
HW8: Add Mooney-Rivlin material model (matyp 9)

### DIFF
--- a/code/constitutive laws/Cauchy_type_selection.m
+++ b/code/constitutive laws/Cauchy_type_selection.m
@@ -20,6 +20,8 @@ switch matyp
          Cauchy = stress7(kinematics,properties,dim);
     case 8
          Cauchy = stress8(kinematics,properties,dim);        
+    case 9
+	 Cauchy = stress9(kinematics,properties,cons);
     case 17
          %-----------------------------------------------------------------
          % Select internal variables at a particular Gauss point (igauss)

--- a/code/constitutive laws/elasticity_modulus_selection.m
+++ b/code/constitutive laws/elasticity_modulus_selection.m
@@ -20,6 +20,8 @@ switch matyp
          c_tensor = ctens7(kinematics,properties,dimension);
     case 8
          c_tensor = ctens8(kinematics,properties,dimension);            
+    case 9
+	 c_tensor = ctens9(kinematics,properties,cons);
     case 17
          %-----------------------------------------------------------------
          % Select internal variables at a particular Gauss point (igauss)

--- a/code/constitutive laws/elasticity_tensor/ctens9.m
+++ b/code/constitutive laws/elasticity_tensor/ctens9.m
@@ -1,0 +1,41 @@
+function c = ctens9(kinematics,properties,cons)
+mu1 = properties(2);
+mu2 = properties(3);
+kappa = properties(4);
+J = kinematics.J;
+b = kinematics.b;
+b2 = b*b;
+I =cons.I;
+c1 = cons.IDENTITY_TENSORS.c1;
+c2 = cons.IDENTITY_TENSORS.c2;
+I1 = trace(b);
+I2 = 0.5*(I1^2 - trace(b*b));
+I1_bar = I1/J^(2/3);
+I2_bar = I2/J^(4/3);
+dim = size(I,1);
+
+cbb = zeros(dim,dim,dim,dim);
+cbs = zeros(dim,dim,dim,dim);
+cbI = zeros(dim,dim,dim,dim);
+cb2I = zeros(dim,dim,dim,dim);
+
+for l = 1:dim
+	for k = 1:dim
+		for j = 1:dim
+			for i = 1:dim
+				cbb(i,j,k,l) = b(i,j)*b(k,l);
+				cbs(i,j,k,l) = b(i,k)*b(j,l) + b(i,l)*b(j,k);
+				cbI(i,j,k,l) = b(i,j)*I(k,l) + I(i,j)*b(k,l);
+				cb2I(i,j,k,l) = b2(i,j)*I(k,l) + I(i,j)*b2(k,l);
+			end
+		end
+	end
+end
+
+c_vol = kappa*(J*(2*J-1)*c1 - J*(J-1)*c2);
+
+c_iso = 2*mu2*(cbb - 0.5*cbs) - (2/3)*(mu1 + 2*mu2*I1_bar)*cbI + (4/3)*mu2*cb2I + (2/9)*(mu1*I1_bar + 4*mu2*I2_bar)*c1 + (1/3)*(mu1*I1_bar + 2*mu2*I2_bar)*c2;
+
+c = c_vol + c_iso;
+end
+

--- a/code/constitutive laws/stress/stress9.m
+++ b/code/constitutive laws/stress/stress9.m
@@ -1,0 +1,17 @@
+function Cauchy = stress9(kinematics,properties,cons)
+mu1 = properties(2);
+mu2 = properties(3);
+kappa = properties(4);
+J = kinematics.J;
+b = kinematics.b;
+I = cons.I;
+I1 = trace(b);
+I2 = 0.5*(I1^2 - trace(b*b));
+I1_bar = I1/J^(2/3);
+I2_bar = I2/J^(4/3);
+tau_vol = J*(J-1)*kappa*I;
+tau_iso = -(1/3)*(mu1*I1_bar + 2*mu2*I2_bar)*I - mu2*(b*b) + ...
+ (mu1 + mu2*I1_bar)*b;
+Cauchy = (tau_vol + tau_iso)/J;
+end
+

--- a/code/input_reading/matprop.m
+++ b/code/input_reading/matprop.m
@@ -40,7 +40,7 @@ function  property_numbers    = material_choice(matyp)
     switch matyp
         case 2
              property_numbers = (1:6);
-        case 4
+        case {4,9}
              property_numbers = (1:4);
         case 17
              property_numbers = (1:5);


### PR DESCRIPTION
- added stress9.m
- added ctens9.m
- updated Cauchy_type_selection.m
- updated elasticity_modulus_selection.m
- updated matprop.m so material 9 reads 4 properties
- Tested using the 1-element 3D incompressible neo-Hookean 